### PR TITLE
Refactor overlays and add dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>GrindSizer — Portafiltro (v2.3)</title>
     <script async src="https://docs.opencv.org/4.x/opencv.js" type="text/javascript"></script>
   </head>
-  <body class="min-h-screen bg-black">
+  <body class="min-h-screen bg-black text-yellow-100">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="black"/>
+  <text x="50" y="55" font-size="50" fill="#f59e0b" text-anchor="middle" font-family="Arial, sans-serif">GS</text>
+</svg>


### PR DESCRIPTION
## Summary
- implement black and yellow theme with visible logo
- make magnifier optional, enable panning and guides
- rework overlay system with new 'all' mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b347994bec832f90b34c9d95b5e828